### PR TITLE
Ceph health check runs once and post-result processing cleaned up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 
+## [0.0.4] - 2015-07-23
+
+### Fixed
+- health check only runs once on failure with details
+- removes processing and conditional over health check result when unnecessary
+
 ## [0.0.3] - 2015-07-14
+
 ### Changed
 - updated sensu-plugin gem to 1.2.0
 

--- a/bin/check-ceph.rb
+++ b/bin/check-ceph.rb
@@ -138,12 +138,9 @@ class CheckCephHealth < Sensu::Plugin::Check::CLI
 
   def run # rubocop:disable all
     result = check_ceph_health
-
-    unless result.start_with?('HEALTH_OK')
-      result = strip_warns(result) if config[:ignore_flags]
-    end
     ok result if result.start_with?('HEALTH_OK')
 
+    result = strip_warns(result) if config[:ignore_flags]
     result += run_cmd('ceph osd tree') if config[:osd_tree]
 
     if result.start_with?('HEALTH_WARN')

--- a/bin/check-ceph.rb
+++ b/bin/check-ceph.rb
@@ -151,6 +151,7 @@ class CheckCephHealth < Sensu::Plugin::Check::CLI
   end
 
   private
+
   def check_ceph_health
     if config[:show_detail]
       run_cmd('ceph health detail')

--- a/bin/check-ceph.rb
+++ b/bin/check-ceph.rb
@@ -137,18 +137,28 @@ class CheckCephHealth < Sensu::Plugin::Check::CLI
   end
 
   def run # rubocop:disable all
-    result = run_cmd('ceph health')
+    result = check_ceph_health
+
     unless result.start_with?('HEALTH_OK')
       result = strip_warns(result) if config[:ignore_flags]
     end
     ok result if result.start_with?('HEALTH_OK')
 
-    result = run_cmd('ceph health detail') if config[:show_detail]
     result += run_cmd('ceph osd tree') if config[:osd_tree]
+
     if result.start_with?('HEALTH_WARN')
       warning result
     else
       critical result
+    end
+  end
+
+  private
+  def check_ceph_health
+    if config[:show_detail]
+      run_cmd('ceph health detail')
+    else
+      run_cmd('ceph health')
     end
   end
 end

--- a/lib/sensu-plugins-ceph/version.rb
+++ b/lib/sensu-plugins-ceph/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsCeph
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 3
+    PATCH = 4
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
Three commits:
1. Prevents `ceph health` from being run twice. Prior to this change we received a message to our monitoring system that our ceph cluster was down. Unfortunately this message also indicated that we had a healthy cluster...
2. Minor restructure so we don't check for HEALTH_OK twice before telling sensu we're okay.
3. Because I didn't run RuboCop for the first two ;(

More details in the commit messages.
