### PR TITLE
Add client name option to interact with Ceph for custom authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## Unreleased
 - nothing
 
+## [0.0.5] - 2015-11-26
+### Added
+- include client name option when interacting with ceph
+
 ## [0.0.4] - 2015-07-31
 ### Changed
 - updated documentation links

--- a/bin/check-ceph.rb
+++ b/bin/check-ceph.rb
@@ -64,6 +64,12 @@ class CheckCephHealth < Sensu::Plugin::Check::CLI
          long: '--cluster',
          proc: proc { |c| " --cluster=#{c}" }
 
+  option :name,
+	 description: 'Optional client name',
+	 short: '-n NAME',
+	 long: '--name',
+	 proc: proc { |n| " --name=#{n}" }
+
   option :timeout,
          description: 'Timeout (default 10)',
          short: '-t SEC',
@@ -97,6 +103,7 @@ class CheckCephHealth < Sensu::Plugin::Check::CLI
       cmd += config[:cluster] if config[:cluster]
       cmd += config[:keyring] if config[:keyring]
       cmd += config[:monitor] if config[:monitor]
+      cmd += config[:name] if config[:name]
       cmd += ' 2>&1'
       Timeout.timeout(config[:timeout]) do
         pipe = IO.popen(cmd)

--- a/bin/check-ceph.rb
+++ b/bin/check-ceph.rb
@@ -65,10 +65,10 @@ class CheckCephHealth < Sensu::Plugin::Check::CLI
          proc: proc { |c| " --cluster=#{c}" }
 
   option :name,
-	 description: 'Optional client name',
-	 short: '-n NAME',
-	 long: '--name',
-	 proc: proc { |n| " --name=#{n}" }
+         description: 'Optional client name',
+         short: '-n NAME',
+         long: '--name',
+         proc: proc { |n| " --name=#{n}" }
 
   option :timeout,
          description: 'Timeout (default 10)',

--- a/bin/metrics-ceph.rb
+++ b/bin/metrics-ceph.rb
@@ -54,6 +54,12 @@ class CephMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--cluster',
          proc: proc { |c| " --cluster=#{c}" }
 
+  option :name,
+         description: 'Optional client name',
+         short: '-n NAME',
+         long: '--name',
+         proc: proc { |n| " --name=#{n}" }
+
   option :timeout,
          description: 'Timeout (default 10)',
          short: '-t SEC',
@@ -73,6 +79,7 @@ class CephMetrics < Sensu::Plugin::Metric::CLI::Graphite
       cmd += config[:cluster] if config[:cluster]
       cmd += config[:keyring] if config[:keyring]
       cmd += config[:monitor] if config[:monitor]
+      cmd += config[:name] if config[:name]
       cmd += ' 2>&1'
       Timeout.timeout(config[:timeout]) do
         pipe = IO.popen(cmd)

--- a/lib/sensu-plugins-ceph/version.rb
+++ b/lib/sensu-plugins-ceph/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsCeph
   module Version
     MAJOR = 0
     MINOR = 0
-    PATCH = 4
+    PATCH = 5
 
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
Hi there

Instead of allowing sensu to use your admin client keyring, using --name allows you to use a more limited custom keyring attached to a different user that sensu-plugins-ceph can use for checks.
