### PR TITLE
Prevent stderr from polluting JSON output

### DIFF
--- a/bin/metrics-ceph.rb
+++ b/bin/metrics-ceph.rb
@@ -80,7 +80,6 @@ class CephMetrics < Sensu::Plugin::Metric::CLI::Graphite
       cmd += config[:keyring] if config[:keyring]
       cmd += config[:monitor] if config[:monitor]
       cmd += config[:name] if config[:name]
-      cmd += ' 2>&1'
       Timeout.timeout(config[:timeout]) do
         pipe = IO.popen(cmd)
         Process.wait(pipe.pid)


### PR DESCRIPTION
The metrics-ceph script output should be pure JSON.

However sometime the a ceph command would output errors/warnings to stderr, which are piped into stdout and therefore end up in the output collected by sensu.

Since it's invalid JSON, sensu reports that as an error.

For instance:

```
myhost/ceph_metrics: Check failed to run: 776: unexpected token at '2016-02-18 19:27:11.034937 7fddc41a9700  0 -- :/1027136 >> 10.1.60.2:6789/0 pipe(0x7fddc0027490 sd=3 :0 s=1 pgs=0 cs=0 l=1 c=0x7fddc0027720).fault

{\"health\":{\"health\":{\"health_services\":[{\"mons\":[]}]},\"timechecks\":{\"epoch\":422,\"round\":2,\"round_status\":\"finished\",\"mons\":
[output truncated ...]
```
