### PR TITLE
check-ceph.rb: Prevent error when no flags are set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Fixed
+- check-ceph.rb: Prevent error when ignored flag isn't set (@jharbott)
+
 ## [1.0.1] - 2017-08-09
 ### Fixed
 - check-ceph.rb: fixed a bug where the ignore flag was not working due to order of operations (@jklare)

--- a/bin/check-ceph.rb
+++ b/bin/check-ceph.rb
@@ -130,11 +130,13 @@ class CheckCephHealth < Sensu::Plugin::Check::CLI
 
   def strip_warns(result)
     r = result.dup
-    r.gsub!(/HEALTH_WARN\ /, '')
-     .gsub!(/\ ?flag\(s\) set/, '')
-     .delete!("\n")
-    config[:ignore_flags].each do |f|
-      r.gsub!(/,?#{f},?/, '')
+    if result.start_with?('HEALTH_WARN')
+      r.gsub!(/HEALTH_WARN\ /, '')
+       .gsub!(/\ ?flag\(s\) set/, '')
+       .delete!("\n")
+      config[:ignore_flags].each do |f|
+        r.gsub!(/,?#{f},?/, '')
+      end
     end
     if r.empty?
       result.gsub(/HEALTH_WARN/, 'HEALTH_OK')


### PR DESCRIPTION
Currently an exception is triggered when check-ceph.rb is called with
"-i someflag" while no flags are set and the cluster status is OK.
This patch avoids the exception.
