### PR TITLE
Fix JSON.parse calls in metrics-ceph*.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [1.0.1] - 2017-08-09
 ### Fixed
 - check-ceph.rb: fixed a bug where the ignore flag was not working due to order of operations (@jklare)
+- metrics-ceph[-osd].rb: fixed invalid call to JSON.parse
 
 ### Added
 - slack badge (@majormoses)

--- a/bin/metrics-ceph-osd.rb
+++ b/bin/metrics-ceph-osd.rb
@@ -78,7 +78,7 @@ class CephOsdMetrics < Sensu::Plugin::Metric::CLI::Graphite
         # Right side of wildcard
         strip2 = config[:pattern].match(/\*.*$/).to_s.delete('*')
         osd_num = socket.gsub(strip1, '').gsub(strip2, '')
-        JSON.parse(data).each do |k, v|
+        ::JSON.parse(data).each do |k, v|
           k = k.gsub(/\/$/, '').gsub(/\//, '_')
           output_data(v, "#{osd_num}.#{k}")
         end

--- a/bin/metrics-ceph.rb
+++ b/bin/metrics-ceph.rb
@@ -105,7 +105,7 @@ class CephMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   def run
     result = run_cmd('ceph status --format=json')
-    data = JSON.parse(result)
+    data = ::JSON.parse(result)
     ignore_keys = %w(pgs_by_state version)
     timestamp = Time.now.to_i
     data['pgmap'].each do |key, val|


### PR DESCRIPTION
Check failed to run: undefined method `parse' for Sensu::Plugin::Metric::CLI::JSON:Class, ["/usr/local/bundle/bin/metrics-ceph.rb:108:in `run'", "/usr/local/bundle/gems/sensu-plugin-4.0.0/lib/sensu-plugin/cli.rb:59:in `block in <class:CLI>'"]

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
