### PR TITLE
check-ceph: fix error with '--ignore-flags'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- check-ceph.rb: fixed an error when '--ignore-flags' is set but the flag is not (@ideaship)
 
 ## [1.0.2] - 2019-06-11
 ### Fixed

--- a/bin/check-ceph.rb
+++ b/bin/check-ceph.rb
@@ -130,9 +130,10 @@ class CheckCephHealth < Sensu::Plugin::Check::CLI
 
   def strip_warns(result)
     r = result.dup
+    # No method chaining (gsub! might return nil)
     r.gsub!(/HEALTH_WARN\ /, '')
-     .gsub!(/\ ?flag\(s\) set/, '')
-     .delete!("\n")
+    r.gsub!(/\ ?flag\(s\) set/, '')
+    r.delete!("\n")
     config[:ignore_flags].each do |f|
       r.gsub!(/,?#{f},?/, '')
     end


### PR DESCRIPTION
This patch fixes an error that occurs if '--ignore-flags' is set but no
flag is reported set by ceph health.

Method chaining in strip_warns fails if the ceph health output does not
match the gsub! patterns "/HEALTH_WARN\ /" and "/\ ?flag\(s\) set/"
(because gsub! returns nil if nothing matches).